### PR TITLE
V1.2.0 dev

### DIFF
--- a/.envscanconfig.json
+++ b/.envscanconfig.json
@@ -2,5 +2,6 @@
   "ignore": {
     "variables": [],
     "files": []
-  }
+  },
+  "priority": "HIGH"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ yarn-error.log*
 .DS_Store
 
 # Testing files
-test/
+test*/
 
 # Environment files
 .env

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ env-guardian set-priority high
 You may reset `scan` results by running the `reset-priority` command.
 
 ```bash
+# Run reset-priority command
 env-guardian reset-priority
 
 # Results

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Helps you keep sensitive values out of source code and organized into a `.env` f
   - Option may have user defined filename added as well, `--to-env .env.local`
   - Any file creation or manipulation will happen in the project's root folder
 - Ignore false positives
-  - Ignore variables or files permanently via `.envscanignore.json`
+  - Ignore variables or files permanently via `.envscanconfig.json`
   - Reset ignores back to default
 
 ---
@@ -129,10 +129,10 @@ env-guardian ignore variableName variableName2
 env-guardian ignore-files path/to/file.js
 ```
 
-These commands will add the desired variables/files to an ignore list (`.envscanignore.json`) found in the root directory.
+These commands will add the desired variables/files to an ignore list (`.envscanconfig.json`) found in the root directory.
 
 ```bash
-# .envscanignore.json
+# .envscanconfig.json
 {
   "ignore": {
     "variables": [

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Helps you keep sensitive values out of source code and organized into a `.env` f
 ## Installation
 
 ```bash
-npm install -g @jkdd/env-guardian@latest
+npm install @jkdd/env-guardian
 ```
 
 ---
@@ -144,4 +144,23 @@ These commands will add the desired variables/files to an ignore list (`.envscan
     ]
   }
 }
+```
+
+#### Set priority level for `scan`
+
+```bash
+# Run set-priority command
+env-guardian set-priority high
+
+# Results
+✔ Priority set to [HIGH]
+```
+
+You may reset `scan` results by running the `reset-priority` command.
+
+```bash
+env-guardian reset-priority
+
+# Results
+🔄 Priority filter reset. All severities will be shown on scan.
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Existing Environment Variables:
 No new suggestions to add to .env # or ex: .env.local
 ```
 
+**Important note:** Environment variables and secrets go into very specific 
+files depending on what language or framework you are using. For a full list 
+of compatible file types and naming conventions, please read the documentation 
+found [here](https://env-guardian.online/docs/env-naming-conventions/env-files).
+
 #### Ignore false positives
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jkdd/env-guardian",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jkdd/env-guardian",
-      "version": "1.1.14",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.0",
@@ -225,15 +225,15 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.14"
+        "color-name": "~1.2.0"
       },
       "engines": {
         "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.14.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.2.0.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
@@ -248,8 +248,8 @@
       }
     },
     "node_modules/create-require": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.14.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.2.0.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
@@ -609,9 +609,9 @@
         "acorn": "^8.4.1",
         "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
-        "create-require": "^1.1.14",
+        "create-require": "^1.2.0",
         "diff": "^4.0.1",
-        "make-error": "^1.1.14",
+        "make-error": "^1.2.0",
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jkdd/env-guardian",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "description": "A CLI tool to scan and manage environment variables with a focus on security and ease of use.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run build",
     "test": "npm run clean && npm run build && npm link --force",
     "test:mac": "npm run test && sudo chmod +x /usr/local/bin/env-guardian && sudo chown $(whoami) /usr/local/bin/env-guardian",
-    "publish-to-npm": "env-guardian reset-ignore --force && npm publish"
+    "publish-to-npm": "env-guardian reset-ignore --force && env-guardian reset-priority && npm publish"
   },
   "keywords": [
     "environment variables",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,7 @@ program
       $ env-guardian --version, -v                          ## Displays current env-guardian version
       $ env-guardian --help, -h                             ## Help. It's self explanatory.
       $ env-guardian --info, -i                             ## Displays information about env-guardian
+      $ env-guardian --valid-env                            ## Displays the list of valid .env file names
 
     Commands:
       $ env-guardian scan                                   ## Scans current directory
@@ -113,6 +114,15 @@ program
       GitHub Repo: 'https://github.com/JasonKentDotDev/env-guardian'
       Documentation: 'https://env-guardian.online/'
     `);
+    process.exit(0);
+  })
+  .option("--valid-env", "Display list of valid filenames for secret files.", () => {
+    console.log(`${chalk.cyan(`
+      Valid Filename conventions:
+    `)}
+    ${chalk.yellow(`
+      ${Array.from(VALID_ENV_FILES).join(`\n      `)}
+    `)}`);
     process.exit(0);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,7 @@ program
       $ env-guardian ignore-files path/to/file.js           ## Adds file(s) to an ignore list
       $ env-guardian ignore-list                            ## Lists all ignored variables and files
       $ env-guardian reset-ignore                           ## Resets ignore list to ignore nothing
+      $ env-guardian reset-ignore -f, --force               ## Skips confirmation to reset ignore list
 
     Tips:
       • Use 'scan' to analyze your project and suggest sensitive vars

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,312 +1,250 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import chalk from 'chalk';
-import fs from 'fs';
-import path from 'path';
+import { Command } from "commander";
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
 import readline from "readline";
-import { scanForEnv } from './index';
+import { scanForEnv, EnvScanResult } from "./index";
 
-interface IgnoreConfig {
-  variables: string[];
-  files: string[];
-}
+const program = new Command();
 
 interface ScanConfig {
-  ignore: IgnoreConfig;
+  ignore: {
+    variables: string[];
+    files: string[];
+  };
   priority?: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
 }
 
-let ignoreConfig: IgnoreConfig = { variables: [], files: [] };
+const CONFIG_FILE = ".envscanconfig.json";
 
-let scanConfig: ScanConfig = { ignore: IgnoreConfig, priority?: undefined };
+// ---------- Load/Save Config ----------
+let scanConfig: ScanConfig = { ignore: { variables: [], files: [] } };
 
 function saveScanConfig() {
-  fs.writeFileSync(".envscanconfig.json", JSON.stringify(scanConfig, null, 2));
-};
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(scanConfig, null, 2));
+}
 
 function loadScanConfig() {
-  if (fs.existsSync(".envscanconfig.json")) {
-    scanConfig = JSON.parse(fs.readFileSync(".envscanconfig.json", "utf-8"));
+  if (fs.existsSync(CONFIG_FILE)) {
+    scanConfig = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
   }
-};
+}
+loadScanConfig();
 
-try {
-  const ignoreConfigPath = path.resolve('.envscanignore.json');
-  if (fs.existsSync(ignoreConfigPath)) {
-    const raw = JSON.parse(fs.readFileSync(ignoreConfigPath, 'utf8'));
-    const loaded = raw.ignore || {};
-    ignoreConfig = {
-      variables: Array.isArray(loaded.variables) ? loaded.variables : [],
-      files: Array.isArray(loaded.files) ? loaded.files : [],
-    };
-  }
-} catch (e) {
-  console.warn('Could not load ignore config:', e);
-};
-
+// ---------- Helpers ----------
 function isIgnored(variable: string, file: string): boolean {
-  if (variable && ignoreConfig.variables.includes(variable)) {
-    return true;
-  }
-
+  if (variable && scanConfig.ignore.variables.includes(variable)) return true;
   if (file) {
     const absFile = path.resolve(file);
-    return ignoreConfig.files.some(
+    return scanConfig.ignore.files.some(
       (ignoredFile) => path.resolve(ignoredFile) === absFile
     );
   }
-
   return false;
-};
+}
 
-
-function saveIgnoreConfig() {
-  const ignoreConfigPath = path.resolve('.envscanignore.json');
-  fs.writeFileSync(
-    ignoreConfigPath,
-    JSON.stringify({ ignore: ignoreConfig }, null, 2)
-  );
-  console.log(chalk.blue(`✨ Updated ignore config at ${ignoreConfigPath}`));
-};
-
-const SEVERITY_ORDER = {
+const SEVERITY_ORDER: Record<"LOW" | "MEDIUM" | "HIGH" | "CRITICAL", number> = {
   LOW: 1,
   MEDIUM: 2,
   HIGH: 3,
   CRITICAL: 4,
 };
 
-const VALID_ENV_FILES = new Set([
-  ".env",
-  ".env.local",
-  ".env.development",
-  ".env.production",
-  ".env.test",
-  ".bashrc",
-  ".zshrc",
-  "config.json",
-  "config.yaml",
-  "config.yml",
-  "secrets.json",
-  "application.yaml",
-  "application.yml",
-  "application.properties",
-  "appsettings.json"
-]);
-
-const program = new Command();
-
+// ---------- Commands ----------
 program
-  .name('@jkdd/env-guardian')
-  .description('A simple CLI program that helps you catch potential senitive values before they are pushed up to your repo publicly.')
-  .version('1.2.0', '-v, --version', 'Output the current version')
-  .helpOption(false)
-  .option('-h, --help', 'Show help for available commands', () => {
-    console.log(`
-    Helpers:
-      $ env-guardian --version, -v                          ## Displays current env-guardian version
-      $ env-guardian --help, -h                             ## Help. It's self explanatory.
-      $ env-guardian --info, -i                             ## Displays information about env-guardian
-      $ env-guardian --valid-env                            ## Displays the list of valid .env file names
+  .command("scan [dir]")
+  .description("Scan project for environment variables")
+  .action((dir = ".") => {
+    const results: EnvScanResult = scanForEnv(path.resolve(dir));
 
-    Commands:
-      $ env-guardian scan                                   ## Scans current directory
-      $ env-guardian scan ./dir                             ## Scans a given directory
-      $ env-guardian scan ./dir --to-env                    ## Adds Suggestions to default .env
-      $ env-guardian scan ./dir --to-env .env.local         ## Adds Suggestions to given .env.*
-      $ env-guardian set-priority level                     ## Scan results only display set priority and above
-      $ env-guardian reset-priority                         ## Resets scan results to display all
-      $ env-guardian ignore variable                        ## Adds variable(s) to an ignore list
-      $ env-guardian ignore-files path/to/file.js           ## Adds file(s) to an ignore list
-      $ env-guardian ignore-list                            ## Lists all ignored variables and files
-      $ env-guardian reset-ignore                           ## Resets ignore list to ignore nothing
-      $ env-guardian reset-ignore -f, --force               ## Skips confirmation to reset ignore list
+    const existing: string[] = [];
+    const suggestions: string[] = [];
 
-    Tips:
-      • Use 'scan' to analyze your project and suggest sensitive vars
-      • Use '--to-env' flag to add suggested sensitive vars to a .env file
-      • Use 'set-priority' to only display scan results from set priority and above
-      • Use 'ignore' or 'ignore-files' to suppress false positives
-      • Run 'reset-ignore' to restore a clean ignore config
-    `);
-    process.exit(0);
-  })
-  .option("-i, --info", "Show program information", () => {
-    console.log(`
-      Name: Env-Guardian
-      Author: Jason Kent <jasonkent.dev@gmail.com>
-      Version: 1.2.0
-      Description: 'A simple CLI program that helps you catch potential senitive values before they are pushed up to your repo publicly.'
-      License: 'MIT'
-      GitHub Repo: 'https://github.com/JasonKentDotDev/env-guardian'
-      Documentation: 'https://env-guardian.online/'
-    `);
-    process.exit(0);
-  })
-  .option("--valid-env", "Display list of valid filenames for secret files.", () => {
-    console.log(`${chalk.cyan(`
-      ✔ Valid Filename conventions:
-    `)} ${chalk.yellow(`
-      ${Array.from(VALID_ENV_FILES).join(`\n      `)}
-    `)}
-      For more info about .env filenames, check out: ${chalk.blueBright('https://env-guardian.online/docs/env-naming-conventions/env-files')}
-    `);
-    process.exit(0);
-  });
+    for (const [key, entry] of Object.entries(results)) {
+      // Ignore rules
+      if (isIgnored(key, entry.usage[0] ?? entry.suggested[0]?.file ?? "")) continue;
 
-program
-  .command('scan')
-  .argument('[dir]', 'directory to scan', '.')
-  .option('--to-env [name]', 'create or append suggestions to user defined .env file (default: .env)')
-  .action((dir, options) => {
-    try {
-      const results = scanForEnv(dir);
-
-      console.log(chalk.bold('\n------------Environment Variable Report------------\n'));
-
-      const existing: string[] = [];
-      const suggestions: string[] = [];
-
-      for (const [variable, entry] of Object.entries(results)) {
-        // Find the highest severity for suggestions
-        let maxSeverity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" | undefined;
-
-        if (entry.suggested.length > 0) {
-          maxSeverity = entry.suggested.reduce((acc, s) => {
-            if (!s.severity) return acc;
-            return SEVERITY_ORDER[s.severity] > SEVERITY_ORDER[acc] ? s.severity : acc;
-          }, "LOW" as "LOW" | "MEDIUM" | "HIGH" | "CRITICAL");
-        }
-
-        // Apply filter if set
+      // Handle USAGE (always LOW severity)
+      if (entry.usage.length > 0) {
         if (
           scanConfig.priority &&
-          maxSeverity &&
+          SEVERITY_ORDER["LOW"] < SEVERITY_ORDER[scanConfig.priority]
+        ) {
+          continue;
+        }
+        existing.push(
+          chalk.green(`✔ ${key}`) +
+            ` (used in: ${entry.usage.map((f) => path.relative(dir, f)).join(", ")})`
+        );
+      }
+
+      // Handle SUGGESTIONS
+      if (entry.suggested.length > 0) {
+        let maxSeverity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" = "LOW";
+        for (const s of entry.suggested) {
+          if (s.severity && SEVERITY_ORDER[s.severity] > SEVERITY_ORDER[maxSeverity]) {
+            maxSeverity = s.severity;
+          }
+        }
+
+        if (
+          scanConfig.priority &&
           SEVERITY_ORDER[maxSeverity] < SEVERITY_ORDER[scanConfig.priority]
         ) {
-          continue; // skip this result
+          continue;
         }
 
-        if (entry.usage.length > 0) {
-          existing.push(
-            chalk.green(`✔ ${variable}`) +
-              ` (used in: ${entry.usage.map((f) => path.relative(dir, f)).join(', ')})`
-          );
-        } else if (entry.suggested.length > 0) {
-          const allFiles = entry.suggested.map((s) => s.file);
+        const coloredLabel =
+          maxSeverity === "CRITICAL"
+            ? chalk.red(`[${maxSeverity}]`)
+            : maxSeverity === "HIGH"
+            ? chalk.hex("#FFA500")(`[${maxSeverity}]`)
+            : maxSeverity === "MEDIUM"
+            ? chalk.yellow(`[${maxSeverity}]`)
+            : chalk.green(`[${maxSeverity}]`);
 
-          if (isIgnored(variable, '') || allFiles.some((f) => isIgnored('', f))) {
-            continue;
-          }
-
-          let maxSeverity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL' = 'LOW';
-          for (const s of entry.suggested) {
-            if (s.severity === 'CRITICAL') maxSeverity = 'CRITICAL';
-            else if (s.severity === 'HIGH' && maxSeverity !== 'CRITICAL') maxSeverity = 'HIGH';
-            else if (s.severity === 'MEDIUM' && !['CRITICAL', 'HIGH'].includes(maxSeverity)) maxSeverity = 'MEDIUM';
-          }
-
-          const coloredLabel =
-            maxSeverity === 'CRITICAL'
-              ? chalk.red(`[${maxSeverity}]`)
-              : maxSeverity === 'HIGH'
-              ? chalk.hex('#FFA500')(`[${maxSeverity}]`)
-              : maxSeverity === 'MEDIUM'
-              ? chalk.yellow(`[${maxSeverity}]`)
-              : chalk.green(`[${maxSeverity}]`);
-
-          const files = entry.suggested.map((s) => path.relative(dir, s.file)).join(', ');
-          suggestions.push(`${coloredLabel} ${chalk.yellow(variable)} (found in: ${files})`);
-        }
+        suggestions.push(
+          `${coloredLabel} ${chalk.yellow(key)} (found in: ${entry.suggested
+            .map((s) => path.relative(dir, s.file))
+            .join(", ")})`
+        );
       }
+    }
 
-      if (existing.length > 0) {
-        console.log(chalk.bold.green('Existing Environment Variables:'));
-        console.log(existing.join('\n'));
-        console.log();
-      }
+    console.log(chalk.bold("\n\n------------Environment Variable Report------------"));
 
-      if (suggestions.length > 0) {
-        console.log(chalk.bold.yellow('⚠ Suggested Environment Variables:'));
-        console.log(suggestions.join('\n'));
-        console.log();
-      }
+    if (existing.length > 0) {
+      console.log(chalk.green("\nExisting Environment Variables:"));
+      existing.forEach((e) => console.log(e));
+    }
 
-      if (options.toEnv) {
-        const envFile = typeof options.toEnv === 'string' ? options.toEnv : '.env';
-        const envPath = path.join(process.cwd(), envFile);
-
-        if (!VALID_ENV_FILES.has(envFile)) {
-          console.log(chalk.red(`
-  ❌ Invalid env file name: ${envFile}.
-  Only the following are allowed: ${Array.from(VALID_ENV_FILES).join(", ")}
-          `))
-        } else {
-          let existingContent = '';
-          if (fs.existsSync(envPath)) {
-            existingContent = fs.readFileSync(envPath, 'utf-8');
-          }
-
-          const newSuggestions = Object.entries(results)
-            .filter(([variable, entry]) => {
-              const allFiles = entry.suggested.map((s) => s.file);
-              return (
-                entry.suggested.length > 0 &&
-                !existingContent.includes(`${variable}=`) &&
-                !isIgnored(variable, '') &&
-                !allFiles.some((f) => isIgnored('', f))
-              );
-            })
-            .map(([variable, entry]) => {
-              const values = entry.suggested
-                .map((v) => v.value)
-                .filter(Boolean);
-              
-              if (values.length > 0) {
-                return `\n${variable}=${values[0]}`;
-              }
-              return `${variable}="Error grabbing value. Fill me in yourself!"`;
-            });
-
-          if (newSuggestions.length > 0) {
-            const envComment = `\n\n
-# Suggested by env-guardian
-# Next Steps include: Renaming envs to their correct format and adding values the scanner didn't manage to grab.
-# For more info on correct formatting of Environment Variables for your language, 
-# visit: https://env-guardian.online/docs/env-naming-conventions/env-variables
-`;
-            fs.appendFileSync(envPath, envComment + newSuggestions.join('\n') + '\n');
-            console.log(chalk.yellow(`✨ Added ${newSuggestions.length} suggestion(s) to ${envFile}`));
-          } else {
-            console.log(chalk.gray(`No new suggestions to add to ${envFile}`));
-          }
-        }
-      }
-    } catch (e) {
-      console.error(chalk.red('❌ [ERROR] scan failed:'), e);
+    if (suggestions.length > 0) {
+      console.log(chalk.yellow("\n⚠ Suggested Environment Variables:"));
+      suggestions.forEach((s) => console.log(s));
+    } else {
+      console.log(chalk.green("\n🎉 Congrats! You have no suggestions detected! 🎉\n"))
     }
   });
 
+// -------- Ignore/Unignore commands --------
 program
-  .command("set-priority <level>")
-  .description("Set minimum severity level to display (low, medium, high, critical)")
-  .action((level: string) => {
-    const upper = level.toUpperCase();
-    const valid: ("LOW" | "MEDIUM" | "HIGH" | "CRITICAL")[] = [
-      "LOW",
-      "MEDIUM",
-      "HIGH",
-      "CRITICAL",
-    ];
+  .command("ignore [variables...]")
+  .description("Ignore one or more environment variables")
+  .action((variables: string[]) => {
+    const variablesToIgnore = variables.map((v) => v.trim()).filter(Boolean);
 
-    if (!valid.includes(upper as any)) {
-      console.log(chalk.red(`❌ Invalid priority "${level}". Use one of: low, medium, high, critical`));
-      process.exit(1);
+    for (const v of variablesToIgnore) {
+      if (!scanConfig.ignore.variables.includes(v)) {
+        scanConfig.ignore.variables.push(v);
+        console.log(chalk.green(`✔ Now ignoring ${v}`));
+      } else {
+        console.log(chalk.gray(`${v} is already ignored`));
+      }
     }
 
-    scanConfig.priority = upper as any;
     saveScanConfig();
-    console.log(chalk.green(`✔ Priority set to [${upper}]`));
+  });
+
+program
+  .command("ignore-files [files...]")
+  .description("Ignore ALL variables in one or more files")
+  .action((files: string[]) => {
+    const filesToIgnore = files.map((f) =>
+      path.relative(process.cwd(), path.resolve(f))
+    );
+
+    for (const f of filesToIgnore) {
+      if (!scanConfig.ignore.files.includes(f)) {
+        scanConfig.ignore.files.push(f);
+        console.log(chalk.green(`✔ Now ignoring ALL variables in ${f}`));
+      } else {
+        console.log(chalk.gray(`ALL variables in ${f} are already ignored`));
+      }
+    }
+
+    saveScanConfig();
+  });
+
+program
+  .command("unignore [variables...]")
+  .description("Stop ignoring one or more environment variables")
+  .action((variables: string[]) => {
+    for (const v of variables) {
+      const index = scanConfig.ignore.variables.indexOf(v);
+      if (index !== -1) {
+        scanConfig.ignore.variables.splice(index, 1);
+        console.log(chalk.green(`✔ No longer ignoring ${v}`));
+      } else {
+        console.log(chalk.gray(`${v} was not ignored`));
+      }
+    }
+    saveScanConfig();
+  });
+
+program
+  .command("unignore-files [files...]")
+  .description("Stop ignoring one or more files")
+  .action((files: string[]) => {
+    const filesToUnignore = files.map((f) =>
+      path.relative(process.cwd(), path.resolve(f))
+    );
+
+    for (const f of filesToUnignore) {
+      const index = scanConfig.ignore.files.indexOf(f);
+      if (index !== -1) {
+        scanConfig.ignore.files.splice(index, 1);
+        console.log(chalk.green(`✔ No longer ignoring ${f}`));
+      } else {
+        console.log(chalk.gray(`${f} was not ignored`));
+      }
+    }
+
+    saveScanConfig();
+  });
+
+program
+  .command("reset-ignore")
+  .description("Reset ignore config to default values")
+  .option("-f, --force", "skip confirmation")
+  .action((options) => {
+    const doReset = () => {
+      scanConfig.ignore = { variables: [], files: [] };
+      saveScanConfig();
+      console.log(chalk.cyan("🔄 Ignore rules have been reset"));
+    };
+
+    if (options.force) {
+      doReset();
+    } else {
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      rl.question("This will overwrite ignore rules. Continue? (y/N) ", (ans) => {
+        rl.close();
+        if (ans.toLowerCase() === "y") doReset();
+        else console.log(chalk.red("❌ Reset canceled"));
+      });
+    }
+  });
+
+// -------- Priority commands --------
+program
+  .command("set-priority <level>")
+  .description("Set minimum severity level for results (low, medium, high, critical)")
+  .action((level: string) => {
+    const severityLevel = level.toUpperCase() as
+      | "LOW"
+      | "MEDIUM"
+      | "HIGH"
+      | "CRITICAL";
+    if (!["LOW", "MEDIUM", "HIGH", "CRITICAL"].includes(severityLevel)) {
+      console.error(
+        chalk.red("❌ Invalid priority. Must be one of: low, medium, high, or critical")
+      );
+      process.exit(1);
+    }
+    scanConfig.priority = severityLevel;
+    saveScanConfig();
+    console.log(chalk.green(`\n✔ Priority set to [${severityLevel}]\n`));
   });
 
 program
@@ -315,131 +253,7 @@ program
   .action(() => {
     scanConfig.priority = undefined;
     saveScanConfig();
-    console.log(chalk.cyan("🔄 Priority filter reset. All severities will be shown on scan."));
-  });
-
-program
-  .command("ignore [variables...]")
-  .description("Ignore one or more environment variables")
-  .action((variables: string[]) => {
-    const variablesToIgnore = variables.map((v) => v.trim()).filter(Boolean);
-
-    for (const v of variablesToIgnore) {
-      if (!ignoreConfig.variables.includes(v)) {
-        ignoreConfig.variables.push(v);
-        console.log(chalk.green(`✔ Now ignoring ${v}`));
-      } else {
-        console.log(chalk.gray(`${v} is already ignored`));
-      }
-    }
-
-    saveIgnoreConfig();
-  });
-
-program
-  .command("ignore-files [files...]")
-  .description("Ignore ALL variables in one or more files")
-  .action((files: string[]) => {
-    const filesToIgnore = files.map((f) => path.relative(process.cwd(), path.resolve(f)));
-
-    for (const f of filesToIgnore) {
-      if (!ignoreConfig.files.includes(f)) {
-        ignoreConfig.files.push(f);
-        console.log(chalk.green(`✔ Now ignoring ALL variables in ${f}`));
-      } else {
-        console.log(chalk.gray(`ALL variables in ${f} are already ignored`));
-      }
-    }
-
-    saveIgnoreConfig();
-  });
-
-program
-  .command("ignore-list")
-  .description("List all currently ignored variables and files")
-  .action(() => {
-    if (ignoreConfig.variables.length === 0 && ignoreConfig.files.length === 0) {
-      console.log(chalk.gray("No ignore rules configured."));
-      return;
-    }
-
-    console.log(chalk.bold("\n🛑 Currently Ignored Rules:\n"));
-
-    for (const v of ignoreConfig.variables) {
-      console.log(chalk.green(`• ${v} (globally)`));
-    }
-    for (const f of ignoreConfig.files) {
-      console.log(chalk.cyan(`• ALL variables in ${f}`));
-    }
-
-    console.log();
-  });
-
-program
-  .command("unignore [variables...]")
-  .description("Stop ignoring one or more environment variables")
-  .action((variables: string[]) => {
-    const variablesToUnignore = variables.map((v) => v.trim()).filter(Boolean);
-
-    for (const v of variablesToUnignore) {
-      if (ignoreConfig.variables.includes(v)) {
-        ignoreConfig.variables = ignoreConfig.variables.filter((item) => item !== v);
-        console.log(chalk.green(`✔ No longer ignoring ${v}`));
-      } else {
-        console.log(chalk.gray(`${v} was not in the ignore list`));
-      }
-    }
-
-    saveIgnoreConfig();
-  });
-
-program
-  .command("unignore-files [files...]")
-  .description("Stop ignoring ALL variables in one or more files")
-  .action((files: string[]) => {
-    const filesToUnignore = files.map((f) =>
-      path.relative(process.cwd(), path.resolve(f))
-    );
-
-    for (const f of filesToUnignore) {
-      if (ignoreConfig.files.includes(f)) {
-        ignoreConfig.files = ignoreConfig.files.filter((item) => item !== f);
-        console.log(chalk.green(`✔ No longer ignoring ALL variables in ${f}`));
-      } else {
-        console.log(chalk.gray(`File ${f} was not in the ignore list`));
-      }
-    }
-
-    saveIgnoreConfig();
-  });
-
-
-program
-  .command("reset-ignore")
-  .description("Reset ignore config to default values")
-  .option("-f, --force", "skip confirmation")
-  .action((options) => {
-    const doReset = () => {
-      const defaultConfig: IgnoreConfig = {
-        variables: [],
-        files: [],
-      };
-      ignoreConfig = defaultConfig;
-      saveIgnoreConfig();
-      console.log(chalk.cyan("🔄 ALL rules in `.envscanignore.json` have been reset"));
-      console.log(chalk.cyan("✅ Reset complete"));
-    };
-
-    if (options.force) {
-      doReset();
-    } else {
-      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-      rl.question("This will overwrite .envscanignore.json. Continue? (y/N) ", (ans) => {
-        rl.close();
-        if (ans.toLowerCase() === "y") doReset();
-        else console.log(chalk.red("❌ Reset canceled"));
-      });
-    }
+    console.log(chalk.cyan("\n🔄 Priority filter reset. All severities will be shown on scan.\n"));
   });
 
 program.parse(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,8 @@ program
       $ env-guardian scan ./dir                             ## Scans a given directory
       $ env-guardian scan ./dir --to-env                    ## Adds Suggestions to default .env
       $ env-guardian scan ./dir --to-env .env.local         ## Adds Suggestions to given .env.*
+      $ env-guardian set-priority level                     ## Scan results only display set priority and above
+      $ env-guardian reset-priority                         ## Resets scan results to display all
       $ env-guardian ignore variable                        ## Adds variable(s) to an ignore list
       $ env-guardian ignore-files path/to/file.js           ## Adds file(s) to an ignore list
       $ env-guardian ignore-list                            ## Lists all ignored variables and files
@@ -123,6 +125,7 @@ program
     Tips:
       • Use 'scan' to analyze your project and suggest sensitive vars
       • Use '--to-env' flag to add suggested sensitive vars to a .env file
+      • Use 'set-priority' to only display scan results from set priority and above
       • Use 'ignore' or 'ignore-files' to suppress false positives
       • Run 'reset-ignore' to restore a clean ignore config
     `);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ const program = new Command();
 program
   .name('@jkdd/env-guardian')
   .description('A simple CLI program that helps you catch potential senitive values before they are pushed up to your repo publicly.')
-  .version('1.1.14', '-v, --version', 'Output the current version')
+  .version('1.2.0', '-v, --version', 'Output the current version')
   .helpOption(false)
   .option('-h, --help', 'Show help for available commands', () => {
     console.log(`
@@ -108,7 +108,7 @@ program
     console.log(`
       Name: Env-Guardian
       Author: Jason Kent <jasonkent.dev@gmail.com>
-      Version: 1.1.14
+      Version: 1.2.0
       Description: 'A simple CLI program that helps you catch potential senitive values before they are pushed up to your repo publicly.'
       License: 'MIT'
       GitHub Repo: 'https://github.com/JasonKentDotDev/env-guardian'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,11 +118,12 @@ program
   })
   .option("--valid-env", "Display list of valid filenames for secret files.", () => {
     console.log(`${chalk.cyan(`
-      Valid Filename conventions:
-    `)}
-    ${chalk.yellow(`
+      ✔ Valid Filename conventions:
+    `)} ${chalk.yellow(`
       ${Array.from(VALID_ENV_FILES).join(`\n      `)}
-    `)}`);
+    `)}
+      For more info about .env filenames, check out: ${chalk.blueBright('https://env-guardian.online/docs/env-naming-conventions/env-files')}
+    `);
     process.exit(0);
   });
 
@@ -191,8 +192,8 @@ program
 
         if (!VALID_ENV_FILES.has(envFile)) {
           console.log(chalk.red(`
-❌ Invalid env file name: ${envFile}.
-Only the following are allowed: ${Array.from(VALID_ENV_FILES).join(", ")}
+  ❌ Invalid env file name: ${envFile}.
+  Only the following are allowed: ${Array.from(VALID_ENV_FILES).join(", ")}
           `))
         } else {
           let existingContent = '';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,6 +299,45 @@ program
   });
 
 program
+  .command("unignore [variables...]")
+  .description("Stop ignoring one or more environment variables")
+  .action((variables: string[]) => {
+    const variablesToUnignore = variables.map((v) => v.trim()).filter(Boolean);
+
+    for (const v of variablesToUnignore) {
+      if (ignoreConfig.variables.includes(v)) {
+        ignoreConfig.variables = ignoreConfig.variables.filter((item) => item !== v);
+        console.log(chalk.green(`✔ No longer ignoring ${v}`));
+      } else {
+        console.log(chalk.gray(`${v} was not in the ignore list`));
+      }
+    }
+
+    saveIgnoreConfig();
+  });
+
+program
+  .command("unignore-files [files...]")
+  .description("Stop ignoring ALL variables in one or more files")
+  .action((files: string[]) => {
+    const filesToUnignore = files.map((f) =>
+      path.relative(process.cwd(), path.resolve(f))
+    );
+
+    for (const f of filesToUnignore) {
+      if (ignoreConfig.files.includes(f)) {
+        ignoreConfig.files = ignoreConfig.files.filter((item) => item !== f);
+        console.log(chalk.green(`✔ No longer ignoring ALL variables in ${f}`));
+      } else {
+        console.log(chalk.gray(`File ${f} was not in the ignore list`));
+      }
+    }
+
+    saveIgnoreConfig();
+  });
+
+
+program
   .command("reset-ignore")
   .description("Reset ignore config to default values")
   .option("-f, --force", "skip confirmation")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -306,7 +306,7 @@ program
 
     scanConfig.priority = upper as any;
     saveScanConfig();
-    console.log(chalk.green(`✔ Priority set to ${upper}`));
+    console.log(chalk.green(`✔ Priority set to [${upper}]`));
   });
 
 program
@@ -315,7 +315,7 @@ program
   .action(() => {
     scanConfig.priority = undefined;
     saveScanConfig();
-    console.log(chalk.cyan("🔄 Priority filter reset. All severities will be shown."));
+    console.log(chalk.cyan("🔄 Priority filter reset. All severities will be shown on scan."));
   });
 
 program


### PR DESCRIPTION
Functionality and Quality of Life changes include:

- `--to-env` flag for `scan` command will only take valid compatible Environment Variable Filenames. Full list [here](https://env-guardian.online/docs/env-naming-conventions/env-files).
- `--valid-env` global flag added to display the list of valid filenames.
- `unignore` and `unignore-files` commands added. More info on how they work [here](https://env-guardian.online/docs/unignore).
- `set-priority` and `reset-priority` commands added. More info on how they work [here](https://env-guardian.online/docs/priority).
- `.envscanignore.json` filename changed to `.envscanconfig.json` and "priority" key gets added with `set-priority` command.
- `--help` display updated for new commands and flags.
- Some outputs have been adjusted for clarity.
- Documentation and README updated accordingly.